### PR TITLE
Shuttle mouse support

### DIFF
--- a/Saturn.sv
+++ b/Saturn.sv
@@ -894,7 +894,9 @@ module emu
 		.JOY2_Y2(joy1_y1),
 
 		.JOY1_TYPE(status[17:15]),
-		.JOY2_TYPE(status[20:18])
+		.JOY2_TYPE(status[20:18]),
+
+		.MOUSE(ps2_mouse)
 	);
 	
 	wire [13:1] CD_BUF_ADDR;

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -353,6 +353,7 @@ module emu
 	wire        forced_scandoubler;
 	wire [10:0] ps2_key;
 	wire [24:0] ps2_mouse;
+	wire [15:0] ps2_mouse_ext;
 	
 	wire [35:0] EXT_BUS;
 	
@@ -407,6 +408,7 @@ module emu
 	
 		.ps2_key(ps2_key),
 		.ps2_mouse(ps2_mouse),
+		.ps2_mouse_ext(ps2_mouse_ext),
 	
 		.EXT_BUS(EXT_BUS)
 	);
@@ -896,7 +898,8 @@ module emu
 		.JOY1_TYPE(status[17:15]),
 		.JOY2_TYPE(status[20:18]),
 
-		.MOUSE(ps2_mouse)
+		.MOUSE(ps2_mouse),
+		.MOUSE_EXT(ps2_mouse_ext)
 	);
 	
 	wire [13:1] CD_BUF_ADDR;

--- a/files.qip
+++ b/files.qip
@@ -13,6 +13,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE rtl/sdram2.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/ddram.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/vdp1_fb.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/hps2pad.sv
+set_global_assignment -name SYSTEMVERILOG_FILE rtl/ps2mouse.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/hps2cdd.sv
 set_global_assignment -name SDC_FILE Saturn.sdc
 set_global_assignment -name SYSTEMVERILOG_FILE Saturn.sv

--- a/rtl/hps2pad.sv
+++ b/rtl/hps2pad.sv
@@ -77,13 +77,13 @@ module HPS2PAD (
 
 	// merge ps2 mouse with p1 joypad mouse
 	wire [3:0] p1_m_flags   = mouse_flags | {2'b0,p1_mjy_dz[7],p1_mjx_dz[7]};
-	wire [3:0] p1_m_buttons = {|MOUSE_EXT[15:8],mouse_buttons[2:0]} | ~JOY1[11: 8];
+	wire [3:0] p1_m_buttons = mouse_buttons | ~JOY1[11: 8];
 	wire [7:0] p1_m_x       = mouse_x | p1_mjx_dz;
 	wire [7:0] p1_m_y       = mouse_y | p1_mjy_dz;
 
 	// merge ps2 mouse with p2 joypad mouse
 	wire [3:0] p2_m_flags   = mouse_flags | {2'b0,p2_mjy_dz[7],p2_mjx_dz[7]};
-	wire [3:0] p2_m_buttons = {mouse_buttons[3:0]} | ~JOY2[11: 8];
+	wire [3:0] p2_m_buttons = mouse_buttons | ~JOY2[11: 8];
 	wire [7:0] p2_m_x       = mouse_x | p2_mjx_dz;
 	wire [7:0] p2_m_y       = mouse_y | p2_mjy_dz;
 

--- a/rtl/hps2pad.sv
+++ b/rtl/hps2pad.sv
@@ -33,43 +33,59 @@ module HPS2PAD (
    input      [24: 0] MOUSE,
    input      [15: 0] MOUSE_EXT
 );
+  //joypad mouse
+	parameter PAD_MOUSE_DEAD_ZONE = 7;
 
-  wire [3:0] mouse_flags;
-  wire [3:0] mouse_buttons;
-  wire [7:0] mouse_x;
-  wire [7:0] mouse_y;
+	wire [3:0] mouse_flags;
+	wire [3:0] mouse_buttons;
+	wire [7:0] mouse_x;
+	wire [7:0] mouse_y;
 
-  // reset x/y delta accumulators after completed read by saturn (mouse STATE1 == 10)
-  wire reset_acc = STATE1 == 5'd10;
+	// reset ps2 mouse delta accumulators after completed read by saturn (PAD_MOUSE STATE == 10)
+	wire reset_acc = (JOY1_TYPE == PAD_MOUSE && STATE1 == 5'd10) || (JOY2_TYPE == PAD_MOUSE && STATE2 == 5'd10);
 
-  ps2_mouse ps2mouse
-  (
-    .clk(CLK),
-    .ce(SMPC_CE),
-    .reset(~RST_N),
+	ps2_mouse ps2mouse
+	(
+		.clk(CLK),
+		.ce(SMPC_CE),
+		.reset(~RST_N),
+		.reset_acc(reset_acc),
 
-    .ps2_mouse(MOUSE),
-    .reset_acc(reset_acc),
+		.ps2_mouse(MOUSE),
+		.ps2_mouse_ext(MOUSE_EXT),
 
-    .flags(mouse_flags),
-    .buttons(mouse_buttons),
-    .x(mouse_x),
-    .y(mouse_y),
-  );
+		.flags(mouse_flags),
+		.buttons(mouse_buttons),
+		.x(mouse_x),
+		.y(mouse_y),
+	);
 
-  //joypad mouse stuff
-	parameter DEAD_ZONE = 7;
-	wire [7:0] mjx =  {JOY1_X1[7],JOY1_X1[7],JOY1_X1[6:3],JOY1_X1[7],JOY1_X1[7]};
-	wire [7:0] mjy = -{JOY1_Y1[7],JOY1_Y1[7],JOY1_Y1[6:3],JOY1_Y1[7],JOY1_Y1[7]};
-	wire [7:0] mjx_dz = ($signed(mjx) > $signed(DEAD_ZONE) || $signed(mjx) < $signed(-DEAD_ZONE)) ? mjx : 0;
-	wire [7:0] mjy_dz = ($signed(mjy) > $signed(DEAD_ZONE) || $signed(mjy) < $signed(-DEAD_ZONE)) ? mjy : 0;
 
-  // merge ps2 mouse with joypad mouse
-  wire [3:0] m_flags   = mouse_flags | {2'b0,mjy_dz[7],mjx_dz[7]};
-  wire [3:0] m_buttons = {|MOUSE_EXT[15:8],mouse_buttons[2:0]} | ~JOY1[11: 8];
+	// scale joypad analog to 37.5%. Default is way too sensitive
+	wire signed [7:0] p1_mjx =  (($signed(JOY1_X1) >>> $signed(2)) + ($signed(JOY1_X1) >>> $signed(3)));
+	wire signed [7:0] p1_mjy = -(($signed(JOY1_Y1) >>> $signed(2)) + ($signed(JOY1_Y1) >>> $signed(3)));
+	// add a little deadzone around neutral on joypad analog
+	wire [7:0] p1_mjx_dz = ($signed(p1_mjx) > $signed(PAD_MOUSE_DEAD_ZONE) || $signed(p1_mjx) < $signed(-PAD_MOUSE_DEAD_ZONE)) ? p1_mjx : 0;
+	wire [7:0] p1_mjy_dz = ($signed(p1_mjy) > $signed(PAD_MOUSE_DEAD_ZONE) || $signed(p1_mjy) < $signed(-PAD_MOUSE_DEAD_ZONE)) ? p1_mjy : 0;
 
-  wire [7:0] m_x = mouse_x | mjx_dz;
-  wire [7:0] m_y = mouse_y | mjy_dz;
+	// scale joypad analog to 37.5%. Default is way too sensitive
+	wire signed [7:0] p2_mjx =  (($signed(JOY2_X1) >>> $signed(2)) + ($signed(JOY2_X1) >>> $signed(3)));
+	wire signed [7:0] p2_mjy = -(($signed(JOY2_Y1) >>> $signed(2)) + ($signed(JOY2_Y1) >>> $signed(3)));
+	// add a little deadzone around neutral on joypad analog
+	wire [7:0] p2_mjx_dz = ($signed(p2_mjx) > $signed(PAD_MOUSE_DEAD_ZONE) || $signed(p2_mjx) < $signed(-PAD_MOUSE_DEAD_ZONE)) ? p2_mjx : 0;
+	wire [7:0] p2_mjy_dz = ($signed(p2_mjy) > $signed(PAD_MOUSE_DEAD_ZONE) || $signed(p2_mjy) < $signed(-PAD_MOUSE_DEAD_ZONE)) ? p2_mjy : 0;
+
+	// merge ps2 mouse with p1 joypad mouse
+	wire [3:0] p1_m_flags   = mouse_flags | {2'b0,p1_mjy_dz[7],p1_mjx_dz[7]};
+	wire [3:0] p1_m_buttons = {|MOUSE_EXT[15:8],mouse_buttons[2:0]} | ~JOY1[11: 8];
+	wire [7:0] p1_m_x       = mouse_x | p1_mjx_dz;
+	wire [7:0] p1_m_y       = mouse_y | p1_mjy_dz;
+
+	// merge ps2 mouse with p2 joypad mouse
+	wire [3:0] p2_m_flags   = mouse_flags | {2'b0,p2_mjy_dz[7],p2_mjx_dz[7]};
+	wire [3:0] p2_m_buttons = {mouse_buttons[3:0]} | ~JOY2[11: 8];
+	wire [7:0] p2_m_x       = mouse_x | p2_mjx_dz;
+	wire [7:0] p2_m_y       = mouse_y | p2_mjy_dz;
 
 	parameter PAD_DIGITAL     = 0;
 	parameter PAD_OFF         = 1;
@@ -81,7 +97,7 @@ module HPS2PAD (
 	
 	bit [ 3: 0] OUT1,OUT2;
 	bit         TL1,TL2;
-  bit [ 4: 0]  STATE1,STATE2;
+	bit [ 4: 0]  STATE1,STATE2;
 	always @(posedge CLK or negedge RST_N) begin
 		
 		if (!RST_N) begin
@@ -115,12 +131,12 @@ module HPS2PAD (
 						5'd1: if (PDR1O[6:5] == 2'b01) begin OUT1 <= 4'hB;                          TL1 <= 1; STATE1 <= 5'd2; end
 						5'd2: if (PDR1O[6:5] == 2'b00) begin OUT1 <= 4'hF;                          TL1 <= 0; STATE1 <= 5'd3; end
 						5'd3: if (PDR1O[6:5] == 2'b01) begin OUT1 <= 4'hF;                          TL1 <= 1; STATE1 <= 5'd4; end
-						5'd4: if (PDR1O[6:5] == 2'b00) begin OUT1 <= m_flags;                       TL1 <= 0; STATE1 <= 5'd5; end
-						5'd5: if (PDR1O[6:5] == 2'b01) begin OUT1 <= m_buttons;                     TL1 <= 1; STATE1 <= 5'd6; end
-						5'd6: if (PDR1O[6:5] == 2'b00) begin OUT1 <= m_x[7:4];                      TL1 <= 0; STATE1 <= 5'd7; end
-						5'd7: if (PDR1O[6:5] == 2'b01) begin OUT1 <= m_x[3:0];                      TL1 <= 1; STATE1 <= 5'd8; end
-						5'd8: if (PDR1O[6:5] == 2'b00) begin OUT1 <= m_y[7:4];                      TL1 <= 0; STATE1 <= 5'd9; end
-						5'd9: if (PDR1O[6:5] == 2'b01) begin OUT1 <= m_y[3:0];                      TL1 <= 1; STATE1 <= 5'd10; end
+						5'd4: if (PDR1O[6:5] == 2'b00) begin OUT1 <= p1_m_flags;                    TL1 <= 0; STATE1 <= 5'd5; end
+						5'd5: if (PDR1O[6:5] == 2'b01) begin OUT1 <= p1_m_buttons;                  TL1 <= 1; STATE1 <= 5'd6; end
+						5'd6: if (PDR1O[6:5] == 2'b00) begin OUT1 <= p1_m_x[7:4];                   TL1 <= 0; STATE1 <= 5'd7; end
+						5'd7: if (PDR1O[6:5] == 2'b01) begin OUT1 <= p1_m_x[3:0];                   TL1 <= 1; STATE1 <= 5'd8; end
+						5'd8: if (PDR1O[6:5] == 2'b00) begin OUT1 <= p1_m_y[7:4];                   TL1 <= 0; STATE1 <= 5'd9; end
+						5'd9: if (PDR1O[6:5] == 2'b01) begin OUT1 <= p1_m_y[3:0];                   TL1 <= 1; STATE1 <= 5'd10; end
 					endcase
 					if (PDR1O[6:5] == 2'b11) begin OUT1 <= 4'h0; TL1 <= 1; STATE1 <= 5'd0; end
 				end
@@ -176,12 +192,12 @@ module HPS2PAD (
 						5'd1: if (PDR2O[6:5] == 2'b01) begin OUT2 <= 4'hB;                          TL2 <= 1; STATE2 <= 5'd2; end
 						5'd2: if (PDR2O[6:5] == 2'b00) begin OUT2 <= 4'hF;                          TL2 <= 0; STATE2 <= 5'd3; end
 						5'd3: if (PDR2O[6:5] == 2'b01) begin OUT2 <= 4'hF;                          TL2 <= 1; STATE2 <= 5'd4; end
-						5'd4: if (PDR2O[6:5] == 2'b00) begin OUT2 <= {2'b00,JOY2_X1[7],JOY2_Y1[7]}; TL2 <= 0; STATE2 <= 5'd5; end
-						5'd5: if (PDR2O[6:5] == 2'b01) begin OUT2 <= JOY2[11: 8];                   TL2 <= 1; STATE2 <= 5'd6; end
-						5'd6: if (PDR2O[6:5] == 2'b00) begin OUT2 <= JOY2_X1[7:4]^4'h8;             TL2 <= 0; STATE2 <= 5'd7; end
-						5'd7: if (PDR2O[6:5] == 2'b01) begin OUT2 <= JOY2_X1[3:0];                  TL2 <= 1; STATE2 <= 5'd8; end
-						5'd8: if (PDR2O[6:5] == 2'b00) begin OUT2 <= JOY2_Y1[7:4]^4'h8;             TL2 <= 0; STATE2 <= 5'd9; end
-						5'd9: if (PDR2O[6:5] == 2'b01) begin OUT2 <= JOY2_Y1[3:0];                  TL2 <= 1; STATE2 <= 5'd10; end
+						5'd4: if (PDR2O[6:5] == 2'b00) begin OUT2 <= p2_m_flags;                    TL2 <= 0; STATE2 <= 5'd5; end
+						5'd5: if (PDR2O[6:5] == 2'b01) begin OUT2 <= p2_m_buttons;                  TL2 <= 1; STATE2 <= 5'd6; end
+						5'd6: if (PDR2O[6:5] == 2'b00) begin OUT2 <= p2_m_x[7:4];                   TL2 <= 0; STATE2 <= 5'd7; end
+						5'd7: if (PDR2O[6:5] == 2'b01) begin OUT2 <= p2_m_x[3:0];                   TL2 <= 1; STATE2 <= 5'd8; end
+						5'd8: if (PDR2O[6:5] == 2'b00) begin OUT2 <= p2_m_y[7:4];                   TL2 <= 0; STATE2 <= 5'd9; end
+						5'd9: if (PDR2O[6:5] == 2'b01) begin OUT2 <= p2_m_y[3:0];                   TL2 <= 1; STATE2 <= 5'd10; end
 					endcase
 					if (PDR2O[6:5] == 2'b11) begin OUT2 <= 4'h0; TL2 <= 1; STATE2 <= 5'd0; end
 				end

--- a/rtl/hps2pad.sv
+++ b/rtl/hps2pad.sv
@@ -27,10 +27,11 @@ module HPS2PAD (
    input      [ 7: 0] JOY2_X2,
    input      [ 7: 0] JOY2_Y2,
 
-	input      [ 2: 0] JOY1_TYPE,
-	input      [ 2: 0] JOY2_TYPE,
+   input      [ 2: 0] JOY1_TYPE,
+   input      [ 2: 0] JOY2_TYPE,
 
-  input      [24: 0] MOUSE
+   input      [24: 0] MOUSE,
+   input      [15: 0] MOUSE_EXT
 );
 
 wire [3:0] mouse_flags;
@@ -101,8 +102,8 @@ ps2_mouse ps2mouse
 						5'd2: if (PDR1O[6:5] == 2'b00) begin OUT1 <= 4'hF;                          TL1 <= 0; STATE1 <= 5'd3; end
 						5'd3: if (PDR1O[6:5] == 2'b01) begin OUT1 <= 4'hF;                          TL1 <= 1; STATE1 <= 5'd4; end
 						5'd4: if (PDR1O[6:5] == 2'b00) begin OUT1 <= mouse_flags;                   TL1 <= 0; STATE1 <= 5'd5; end
-						5'd5: if (PDR1O[6:5] == 2'b01) begin OUT1 <= {~JOY1[11],mouse_buttons[2:0]};                   
-                                                                                        TL1 <= 1; STATE1 <= 5'd6; end
+						5'd5: if (PDR1O[6:5] == 2'b01) begin OUT1 <= {|MOUSE_EXT[15:8],mouse_buttons[2:0]};
+																														    TL1 <= 1; STATE1 <= 5'd6; end
 						5'd6: if (PDR1O[6:5] == 2'b00) begin OUT1 <= mouse_x[7:4];                  TL1 <= 0; STATE1 <= 5'd7; end
 						5'd7: if (PDR1O[6:5] == 2'b01) begin OUT1 <= mouse_x[3:0];                  TL1 <= 1; STATE1 <= 5'd8; end
 						5'd8: if (PDR1O[6:5] == 2'b00) begin OUT1 <= mouse_y[7:4];                  TL1 <= 0; STATE1 <= 5'd9; end

--- a/rtl/ps2mouse.sv
+++ b/rtl/ps2mouse.sv
@@ -1,0 +1,94 @@
+`timescale 1ns / 100ps
+
+/*
+ * PS2 mouse protocol
+ * Bit       7    6    5    4    3    2    1    0  
+ * Byte 0: YOVR XOVR YSGN XSGN   1   MBUT RBUT LBUT
+ * Byte 1:                 XMOVE
+ * Byte 2:                 YMOVE
+ */
+
+module ps2_mouse
+(
+	input	clk,
+	input	ce,
+
+	input	reset,
+
+	input [24:0] ps2_mouse,
+  input reset_acc,
+
+	output reg [3:0] flags,
+	output reg [3:0] buttons,
+	output reg [7:0] x,
+	output reg [7:0] y
+);
+
+
+reg [10:0] curdx;
+reg [10:0] curdy;
+wire [10:0] newdx = curdx + {{3{ps2_mouse[4]}},ps2_mouse[15:8]};
+wire [10:0] newdy = curdy + {{3{ps2_mouse[5]}},ps2_mouse[23:16]};
+//wire [10:0] newdx = curdx + {{2{ps2_mouse[4]}},ps2_mouse[15: 8],1'b0};
+//wire [10:0] newdy = curdy + {{2{ps2_mouse[5]}},ps2_mouse[23:16],1'b0};
+wire  [7:0] dx = curdx[7:0];
+wire  [7:0] dy = curdy[7:0];
+
+/* flags bits */
+wire x_ov_p = ($signed(newdx) > $signed( 10'd255));
+wire x_ov_n = ($signed(newdx) < $signed(-10'd256));
+wire x_ov = x_ov_p | x_ov_n;
+wire y_ov_p = ($signed(newdy) > $signed( 10'd255));
+wire y_ov_n = ($signed(newdy) < $signed(-10'd256));
+wire y_ov = y_ov_p | y_ov_n;
+wire sdx = newdx[10];
+wire sdy = newdy[10];
+
+wire strobe = (old_stb != ps2_mouse[24]);
+reg  old_stb = 0;
+always @(posedge clk) old_stb <= ps2_mouse[24];
+
+/* Capture flags state */
+always@(posedge clk or posedge reset or posedge reset_acc) begin
+  if (reset || reset_acc) flags[3:0] <= 4'b0;
+  else if (strobe) begin
+    flags <= {y_ov,x_ov,sdy,sdx};
+  end
+end
+
+/* Clip x accumulator */
+always@(posedge clk or posedge reset or posedge reset_acc) begin
+  if (reset || reset_acc) curdx <= 0;
+  else if (strobe) begin
+    if(x_ov_p) curdx <= 10'd255;
+    else if(x_ov_n) curdx <= -10'd256;
+    else curdx <= newdx;
+  end
+end
+
+/* Clip y accumulator */
+always@(posedge clk or posedge reset or posedge reset_acc) begin
+  if (reset || reset_acc) curdy <= 0;
+  else if (strobe) begin
+    if(y_ov_p) curdy <= 10'd255;
+    else if(y_ov_n) curdy <= -10'd256;
+    else curdy <= newdy;
+  end
+end
+
+/* Capture button state */
+always@(posedge clk or posedge reset)
+	if (reset) buttons[3:0] <= 4'b0;
+	else if (strobe) buttons[3:0] <= {1'b0,ps2_mouse[2:0]};
+
+always@(posedge clk or posedge reset) begin
+	if (reset) x <= 0;
+  else x <= dx;
+end
+
+always@(posedge clk or posedge reset) begin
+	if (reset) y <= 0;
+  else y <= dy;
+end
+
+endmodule

--- a/rtl/ps2mouse.sv
+++ b/rtl/ps2mouse.sv
@@ -29,8 +29,6 @@ reg [10:0] curdx;
 reg [10:0] curdy;
 wire [10:0] newdx = curdx + {{3{ps2_mouse[4]}},ps2_mouse[15:8]};
 wire [10:0] newdy = curdy + {{3{ps2_mouse[5]}},ps2_mouse[23:16]};
-//wire [10:0] newdx = curdx + {{2{ps2_mouse[4]}},ps2_mouse[15: 8],1'b0};
-//wire [10:0] newdy = curdy + {{2{ps2_mouse[5]}},ps2_mouse[23:16],1'b0};
 wire  [7:0] dx = curdx[7:0];
 wire  [7:0] dy = curdy[7:0];
 

--- a/rtl/ps2mouse.sv
+++ b/rtl/ps2mouse.sv
@@ -14,9 +14,10 @@ module ps2_mouse
 	input	ce,
 
 	input	reset,
+  input reset_acc,
 
 	input [24:0] ps2_mouse,
-  input reset_acc,
+	input [15:0] ps2_mouse_ext,
 
 	output reg [3:0] flags,
 	output reg [3:0] buttons,
@@ -77,7 +78,7 @@ end
 /* Capture button state */
 always@(posedge clk or posedge reset)
 	if (reset) buttons[3:0] <= 4'b0;
-	else if (strobe) buttons[3:0] <= {1'b0,ps2_mouse[2:0]};
+	else if (strobe) buttons[3:0] <= {|ps2_mouse_ext[15:8],ps2_mouse[2:0]};
 
 always@(posedge clk or posedge reset) begin
 	if (reset) x <= 0;

--- a/rtl/ps2mouse.sv
+++ b/rtl/ps2mouse.sv
@@ -14,7 +14,7 @@ module ps2_mouse
 	input	ce,
 
 	input	reset,
-  input reset_acc,
+	input	reset_acc,
 
 	input [24:0] ps2_mouse,
 	input [15:0] ps2_mouse_ext,
@@ -49,30 +49,30 @@ always @(posedge clk) old_stb <= ps2_mouse[24];
 
 /* Capture flags state */
 always@(posedge clk or posedge reset or posedge reset_acc) begin
-  if (reset || reset_acc) flags[3:0] <= 4'b0;
-  else if (strobe) begin
-    flags <= {y_ov,x_ov,sdy,sdx};
-  end
+	if (reset || reset_acc) flags[3:0] <= 4'b0;
+	else if (strobe) begin
+		flags <= {y_ov,x_ov,sdy,sdx};
+	end
 end
 
 /* Clip x accumulator */
 always@(posedge clk or posedge reset or posedge reset_acc) begin
-  if (reset || reset_acc) curdx <= 0;
-  else if (strobe) begin
-    if(x_ov_p) curdx <= 10'd255;
-    else if(x_ov_n) curdx <= -10'd256;
-    else curdx <= newdx;
-  end
+	if (reset || reset_acc) curdx <= 0;
+	else if (strobe) begin
+		if(x_ov_p) curdx <= 10'd255;
+		else if(x_ov_n) curdx <= -10'd256;
+		else curdx <= newdx;
+	end
 end
 
 /* Clip y accumulator */
 always@(posedge clk or posedge reset or posedge reset_acc) begin
-  if (reset || reset_acc) curdy <= 0;
-  else if (strobe) begin
-    if(y_ov_p) curdy <= 10'd255;
-    else if(y_ov_n) curdy <= -10'd256;
-    else curdy <= newdy;
-  end
+	if (reset || reset_acc) curdy <= 0;
+	else if (strobe) begin
+		if(y_ov_p) curdy <= 10'd255;
+		else if(y_ov_n) curdy <= -10'd256;
+		else curdy <= newdy;
+	end
 end
 
 /* Capture button state */
@@ -82,12 +82,12 @@ always@(posedge clk or posedge reset)
 
 always@(posedge clk or posedge reset) begin
 	if (reset) x <= 0;
-  else x <= dx;
+	else x <= dx;
 end
 
 always@(posedge clk or posedge reset) begin
 	if (reset) y <= 0;
-  else y <= dy;
+	else y <= dy;
 end
 
 endmodule


### PR DESCRIPTION
Closes #146

Details:

* Maps a USB mouse to p1/p2 Saturn Shuttle mouse
* Fixes joypad analog stick as mouse
* Merges inputs between the joypad and usb mouse, so you can swap between each on-the-fly
   - Maybe you like to use joypad for most of the game, but use the mouse for the shooting sections. Go for it.
   
* L/M/R USB mouse buttons map to Shuttle Mouse L/M/R buttons.
* Any extra USB mouse buttons detected are merged together as the 4th mouse button (Saturn Start).
   - for example, side buttons for page forward/page back
   
* Joypad analog as mouse is oversensitive just sending raw deltas, so it's scaled down to 37.5%. 
   - Maybe this could be a sensitivity setting in the future.