### PR TITLE
add "Black Transitions" option

### DIFF
--- a/Saturn.sv
+++ b/Saturn.sv
@@ -242,7 +242,7 @@ module emu
 	`include "build_id.v"
 	localparam CONF_STR = {
 		"Saturn;;",
-		"S0,CUECHD,Insert Disk;",
+		"S0,CUECHD,Insert Disc;",
 		"FS2,BIN,Load bios;",
 		"FS3,BIN,Load cartridge;",
 		"-;",

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -52,6 +52,7 @@ module emu
 	input  [11:0] HDMI_WIDTH,
 	input  [11:0] HDMI_HEIGHT,
 	output        HDMI_FREEZE,
+	output        HDMI_BLACKOUT,
 
 `ifdef MISTER_FB
 	// Use framebuffer in DDRAM (USE_FB=1 in qsf)
@@ -258,6 +259,7 @@ module emu
 		"P1OA,Aspect Ratio,4:3,Stretched;",
 		"P1OB,320x224 Aspect,Original,Corrected;",
 		"P1OT,Deinterlacing, Weave, Bob;",
+		"P1O[1],Black Transitions,On,Off;",
 //		"P1O13,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
 //		"P1-;",
 //		"P1OC,Border,No,Yes;",
@@ -366,6 +368,8 @@ module emu
 	
 	wire [21:0] gamma_bus;
 	wire [15:0] sdram_sz;
+        
+	assign HDMI_BLACKOUT = ~status[1];
 	
 	hps_io #(.CONF_STR(CONF_STR), .WIDE(1)) hps_io
 	(

--- a/sys/ascal.vhd
+++ b/sys/ascal.vhd
@@ -222,7 +222,8 @@ ENTITY ascal IS
 		vmax    : IN natural RANGE 0 TO 4095; -- 0 <= vmin < vmax < vdisp
 		vrr     : IN std_logic := '0';
 		vrrmax  : IN natural RANGE 0 TO 4095 := 0;
-
+		swblack : IN std_logic := '0';        -- will output 3 black frame on every resolution switch
+		
 		-- Scaler format. 00=16bpp 565, 01=24bpp 10=32bpp
 		format  : IN unsigned(1 DOWNTO 0) :="01";
 
@@ -510,7 +511,8 @@ ARCHITECTURE rtl OF ascal IS
 	SIGNAL o_divrun : std_logic;
 	SIGNAL o_hacpt,o_vacpt : unsigned(11 DOWNTO 0);
 	SIGNAL o_vacptl : unsigned(1 DOWNTO 0);
-
+	SIGNAL o_newres : integer range 0 to 3;
+				 
 	-----------------------------------------------------------------------------
 	FUNCTION shift_ishift(shift : unsigned(0 TO 119);
 												pix   : type_pix;
@@ -1890,7 +1892,17 @@ BEGIN
 				o_ivsize<=i_vrsize; -- <ASYNC>
 				o_hdown<=i_hdown; -- <ASYNC>
 				o_vdown<=i_vdown; -- <ASYNC>
+			
+				IF (o_newres > 0) THEN
+					o_newres <= o_newres- 1;
+				END IF;
 			END IF;
+
+			IF (swblack = '1' and o_fb_ena = '0' and (o_ihsize /= i_hrsize or o_ivsize /= i_vrsize)) then
+				o_newres <= 3;
+			END IF;
+
+
 
 			-- Simultaneous change of input and output framebuffers
 			IF o_vsv(1)='1' AND o_vsv(0)='0' AND
@@ -2218,6 +2230,9 @@ BEGIN
 					-- 8bpp indexed colour mode
 					hpix_v:=(r=>o_fb_pal_dr(23 DOWNTO 16),g=>o_fb_pal_dr(15 DOWNTO 8),
 									 b=>o_fb_pal_dr(7 DOWNTO 0));
+				END IF;
+				IF (o_newres > 0) THEN
+					hpix_v := (others => (others => '0'));
 				END IF;
 				o_hpix0<=hpix_v;
 				o_hpix1<=o_hpix0;

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -330,6 +330,7 @@ reg [11:0] vs_line = 0;
 
 reg        scaler_out = 0;
 reg        vrr_mode = 0;
+wire       hdmi_blackout;
 
 reg [31:0] aflt_rate = 7056000;
 reg [39:0] acx  = 4258969;
@@ -751,6 +752,7 @@ wire         freeze;
 		.vmax     (vmax),
 		.vrr      (vrr_mode),
 		.vrrmax   (HEIGHT + VBP + VS[11:0] + 12'd1),
+		.swblack  (hdmi_blackout),
 
 		.mode     ({~lowlat,LFB_EN ? LFB_FLT : |scaler_flt,2'b00}),
 		.poly_clk (clk_sys),
@@ -1707,7 +1709,8 @@ emu emu
 	.HDMI_WIDTH(direct_video ? 12'd0 : hdmi_width),
 	.HDMI_HEIGHT(direct_video ? 12'd0 : hdmi_height),
 	.HDMI_FREEZE(freeze),
-
+	.HDMI_BLACKOUT(hdmi_blackout),
+	
 	.CLK_VIDEO(clk_vid),
 	.CE_PIXEL(ce_pix),
 	.VGA_SL(scanlines),


### PR DESCRIPTION
- Any resolution change will cause the HDMI scaler to display 3 black frames to hide garbage from the resolution change, during game change or reset.  On/off capability in the audio and video sections - based on the Fpgazumspass code for PSX.

- fix typo in the line "insert disk" => "insert disc"
