### PR TITLE
Fix case of some paths

### DIFF
--- a/files.qip
+++ b/files.qip
@@ -3,7 +3,7 @@ set_global_assignment -name QIP_FILE rtl/SH/SH7604/SH7604.qip
 set_global_assignment -name QIP_FILE rtl/SH/SH7034/SH7034.qip
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/SH_mem.sv
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/SH7604_mem.sv
-set_global_assignment -name QIP_FILE rtl/ADSP_21XX/ADSP_2181.qip
+set_global_assignment -name QIP_FILE rtl/ADSP_21xx/ADSP_2181.qip
 set_global_assignment -name SYSTEMVERILOG_FILE rtl/ADSP_21XX_mem.sv
 set_global_assignment -name QIP_FILE rtl/Saturn/Saturn.qip
 set_global_assignment -name VHDL_FILE rtl/CEGen.vhd

--- a/rtl/ADSP_21xx/ADSP_2181.qip
+++ b/rtl/ADSP_21xx/ADSP_2181.qip
@@ -1,3 +1,3 @@
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) ADSP_21XX_pkg.sv ]
-set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) ADSP_21xx_core.sv ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) ADSP_21XX_core.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) ADSP_2181.sv ]


### PR DESCRIPTION
Build failed in the unstable builder, and fails to compile on linux. I assume it works on windows due to windows not caring about case of filenames/directories.

I changed the qip files instead of just renaming the directory since I don't know if that would cause problems on an existing windows repo. 