### PR TITLE
verilator lint OK

### DIFF
--- a/rtl/SH/SH7604/BSC.sv
+++ b/rtl/SH/SH7604/BSC.sv
@@ -148,8 +148,8 @@ module SH7604_BSC
 		return {~BCR1.DRAM[1] & BCR1.DRAM[0],BCR1.DRAM[2],2'b00};
 	endfunction 
 	
-	function bit [3:0] SDRAMBank(input bit [26:0] A, input MCR_t MCR);
-		bit       res;
+	function bit SDRAMBank(input bit [26:0] A, input MCR_t MCR);
+		bit res;
 	
 		case ({MCR.SZ,MCR.AMX2,MCR.AMX})
 			4'b1000: res = A[21];
@@ -253,7 +253,7 @@ module SH7604_BSC
 						BS_N <= 1;
 						case (GetAreaW(A[26:25],WCR))
 							2'b00: begin
-								if (!NEXT_BA) begin
+								if (NEXT_BA == 4'd0) begin
 									if (CBUS_ACTIVE && !BUS_WE_LATCH) CBUSY <= 0;
 									if (DBUS_ACTIVE && !BUS_WE_LATCH) DBUSY <= 0;
 									BUSY <= 0;
@@ -283,11 +283,11 @@ module SH7604_BSC
 				
 				TW: begin
 					if (CE_R) begin
-						if (WAIT_CNT && !FAST) begin
+						if ((WAIT_CNT != 3'd0) && !FAST) begin
 							WAIT_CNT <= WAIT_CNT - 3'd1;
 						end
 						else if (WAIT_N) begin
-							if (!NEXT_BA) begin
+							if (NEXT_BA == 4'd0) begin
 								if (CBUS_ACTIVE && !BUS_WE_LATCH) CBUSY <= 0;
 								if (DBUS_ACTIVE && !BUS_WE_LATCH) DBUSY <= 0;
 								BUSY <= 0;
@@ -318,7 +318,7 @@ module SH7604_BSC
 							BURST_EN <= 0;
 						end
 						STATE_NEXT = T1;
-						if (!NEXT_BA) begin
+						if (NEXT_BA == 4'd0) begin
 							if (BURST_EN && !BURST_LAST) begin
 								CBUSY <= 1;
 							end
@@ -336,7 +336,7 @@ module SH7604_BSC
 						BS_N <= 1;
 						if (BUS_WE_LATCH) begin
 							if (WAIT_N || !LL) begin
-								if (!NEXT_BA) begin
+								if (NEXT_BA == 4'd0) begin
 									BUSY <= 0;
 								end
 								NOP_WAIT_CNT <= 2'd1;
@@ -354,7 +354,7 @@ module SH7604_BSC
 						CACK <= 0;
 					end
 					if (CE_R) begin
-						if (!NEXT_BA) begin
+						if (NEXT_BA == 4'd0) begin
 							CS0_N <= 1;
 							CS1_N <= 1;
 							CS2_N <= 1;
@@ -368,7 +368,7 @@ module SH7604_BSC
 				
 				TWNOP: begin
 					if (CE_R) begin
-						if (NOP_WAIT_CNT) begin
+						if (NOP_WAIT_CNT != 2'd0) begin
 							NOP_WAIT_CNT <= NOP_WAIT_CNT - 2'd1;
 						end else begin
 							STATE_NEXT = T0;
@@ -378,11 +378,11 @@ module SH7604_BSC
 				
 				TRCAS: begin
 					if (CE_R) begin
-						if (RCD_WAIT_CNT && !FAST) begin
+						if ((RCD_WAIT_CNT != 2'd0) && !FAST) begin
 							RCD_WAIT_CNT <= RCD_WAIT_CNT - 2'd1;
 						end
 						else if (WAIT_N || !LL) begin
-							if (!NEXT_BA) begin
+							if (NEXT_BA == 4'd0) begin
 								if (CBUS_ACTIVE && !BURST_SINGLE) CBUSY <= 0;
 								if (DBUS_ACTIVE && !BURST_SINGLE) DBUSY <= 0;
 								BUSY <= 0;
@@ -426,7 +426,7 @@ module SH7604_BSC
 				
 				TRFS1: begin
 					if (CE_R) begin
-						if (RFS_WAIT_CNT && !FAST) begin
+						if ((RFS_WAIT_CNT != 2'd0) && !FAST) begin
 							RFS_WAIT_CNT <= RFS_WAIT_CNT - 2'd1;
 						end
 						else begin
@@ -515,7 +515,7 @@ module SH7604_BSC
 					DBUS_IS_SDRAM = IsSDRAMArea(DBUS_A[26:25],BCR1); 
 					BUS_IS_SDRAM = IsSDRAMArea(A[26:25],BCR1);
 					VBUS_ACTIVE <= 0;
-					if (((BUS_STATE == T2 || BUS_STATE == TWCAS || BUS_STATE == TRD) && BUSY && NEXT_BA) || ((BUS_STATE == T2 || BUS_STATE == TRD) && BURST_EN && !BURST_LAST)) begin
+					if (((BUS_STATE == T2 || BUS_STATE == TWCAS || BUS_STATE == TRD) && BUSY && (NEXT_BA != 4'd0)) || ((BUS_STATE == T2 || BUS_STATE == TRD) && BURST_EN && !BURST_LAST)) begin
 						case (AREA_SZ)
 							2'b01: if (!SIZE_BYTE_DISABLE) begin 
 								A[3:0] <= A[3:0] + 4'd1; 
@@ -586,7 +586,7 @@ module SH7604_BSC
 							if (INSERT_WAIT && !BUS_WE_LATCH && !BUS_IS_SDRAM) begin
 								A <= CBUS_A[26:0];
 								INSERT_WAIT <= 0;
-							end else if (BUS_STATE == T0 || BUS_STATE == T2 /*|| BUS_STATE == TWCAS*/ || (BUS_STATE == TWNOP && !NOP_WAIT_CNT) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
+							end else if (BUS_STATE == T0 || BUS_STATE == T2 /*|| BUS_STATE == TWCAS*/ || (BUS_STATE == TWNOP && (NOP_WAIT_CNT == 2'd0)) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
 								REFRESH_ACTIVE <= 1;
 								INSERT_WAIT <= ~FAST;
 								A[24:0] <= '0;
@@ -611,7 +611,7 @@ module SH7604_BSC
 							end
 						end 
 						else if (VBUS_REQ && !CBUS_LOCK_INT && !DBUS_LOCK_INT) begin
-							if (BUS_STATE == T0 || BUS_STATE == T2 || (BUS_STATE == TWNOP && !NOP_WAIT_CNT) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
+							if (BUS_STATE == T0 || BUS_STATE == T2 || (BUS_STATE == TWNOP && (NOP_WAIT_CNT == 2'd0)) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
 								VBUS_ACTIVE <= 1;
 								A <= {23'h000000,VBUS_A};
 								DO <= '0; 
@@ -638,7 +638,7 @@ module SH7604_BSC
 							if (INSERT_WAIT && ((A[26:25] != DBUS_A[26:25] && !DBUS_WE && !BUS_WE_LATCH && !DBUS_IS_SDRAM) || (DBUS_WE && !BUS_WE_LATCH && !DBUS_IS_SDRAM) || (DBUS_WE && BUS_STATE == T0 && !DBUS_IS_SDRAM) || (!DBUS_LOCK_INT && !MASTER))) begin
 								A <= DBUS_A[26:0];
 								INSERT_WAIT <= 0;
-							end else if (BUS_STATE == T0 || BUS_STATE == T2 || (BUS_STATE == TWCAS && !SDRAM_INSERT_NOP && !DELAYED_RFS_REQ) || (BUS_STATE == TWNOP && !NOP_WAIT_CNT) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
+							end else if (BUS_STATE == T0 || BUS_STATE == T2 || (BUS_STATE == TWCAS && !SDRAM_INSERT_NOP && !DELAYED_RFS_REQ) || (BUS_STATE == TWNOP && (NOP_WAIT_CNT == 2'd0)) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
 								DBUS_ACTIVE <= 1;
 								DBUS_SKIP <= 1;
 								DBUS_LOCK_INT <= DBUS_LOCK;
@@ -759,11 +759,11 @@ module SH7604_BSC
 							IS_SAME_BANK_SDRAM = (SDRAMBank(A,MCR) == SDRAMBank(CBUS_A[26:0],MCR));
 							SDRAM_INSERT_NOP = IS_SAME_BANK_SDRAM && BUS_WE_LATCH && CBUS_IS_SDRAM;
 							if (INSERT_WAIT && ((A[26:25] != CBUS_A[26:25] && !CBUS_WE && !BUS_WE_LATCH && !CBUS_IS_SDRAM) || (CBUS_WE && !BUS_WE_LATCH && !CBUS_IS_SDRAM) || (CBUS_WE && BUS_STATE == T0 && !CBUS_IS_SDRAM) || (CBUS_WE && REFRESH_ACTIVE) || 
-							                    (CBUS_WE && CBUS_REQ_CNT == 2'd3 && (BRLS || !MASTER) && !NOP_WAIT_CNT))) begin
+							                    (CBUS_WE && CBUS_REQ_CNT == 2'd3 && (BRLS || !MASTER) && (NOP_WAIT_CNT == 2'd0)))) begin
 								A <= CBUS_A[26:0];
 								INSERT_WAIT <= 0;
 								CBUS_REQ_CNT <= 2'd0;
-							end else if (BUS_STATE == T0 || BUS_STATE == T2 || (BUS_STATE == TWCAS && !SDRAM_INSERT_NOP && !DELAYED_RFS_REQ) || (BUS_STATE == TWNOP && !NOP_WAIT_CNT) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
+							end else if (BUS_STATE == T0 || BUS_STATE == T2 || (BUS_STATE == TWCAS && !SDRAM_INSERT_NOP && !DELAYED_RFS_REQ) || (BUS_STATE == TWNOP && (NOP_WAIT_CNT == 2'd0)) || BUS_STATE == TRD || BUS_STATE == TRFS2) begin
 								CBUS_ACTIVE <= 1;
 								DBUS_SKIP <= 0;
 								if (CBUS_WE && CBUS_REQ_CNT < 2'd3) CBUS_REQ_CNT <= CBUS_REQ_CNT + 2'd1;
@@ -1010,8 +1010,8 @@ module SH7604_BSC
 					5'h08: REG_DO[15:0] <= WCR & WCR_RMASK;
 					5'h0C: REG_DO[15:0] <= MCR & MCR_RMASK;
 					5'h10: REG_DO[15:0] <= RTCSR & RTCSR_RMASK;
-					5'h14: REG_DO[15:0] <= {8'h00,RTCNT} & RTCNT_RMASK;
-					5'h18: REG_DO[15:0] <= {8'h00,RTCOR} & RTCOR_RMASK;
+					5'h14: REG_DO[15:0] <= {8'h00,RTCNT} & {8'h00,RTCNT_RMASK};
+					5'h18: REG_DO[15:0] <= {8'h00,RTCOR} & {8'h00,RTCOR_RMASK};
 					default:REG_DO[15:0] <= '0;
 				endcase
 			end

--- a/rtl/SH/SH7604/DIVU.sv
+++ b/rtl/SH/SH7604/DIVU.sv
@@ -172,11 +172,11 @@ module SH7604_DIVU (
 					5'h00: DVSR <= IBUS_DI & DVSR_WMASK;
 					5'h04: {DVDNTH,DVDNTL} <= {{32{IBUS_DI[31]}},IBUS_DI} & {DVDNT_WMASK,DVDNT_WMASK};
 					5'h08: begin
-						if (IBUS_BA[3:2]) DVCR[31:16] <= IBUS_DI[31:16] & DVCR_WMASK[31:16];
-						if (IBUS_BA[1:0]) DVCR[15:0]  <= IBUS_DI[15:0]  & DVCR_WMASK[15:0];
+						if (IBUS_BA[3:2] != 2'b00) DVCR[31:16] <= IBUS_DI[31:16] & DVCR_WMASK[31:16];
+						if (IBUS_BA[1:0] != 2'b00) DVCR[15:0]  <= IBUS_DI[15:0]  & DVCR_WMASK[15:0];
 					end
 					5'h0C: begin
-						if (IBUS_BA[1:0]) VCRDIV[15:0] <= IBUS_DI[15:0] & VCRDIV_WMASK[15:0];
+						if (IBUS_BA[1:0] != 2'b00) VCRDIV[15:0] <= IBUS_DI[15:0] & VCRDIV_WMASK[15:0];
 					end
 					5'h10: DVDNTH <= IBUS_DI & DVDNT_WMASK;
 					5'h14: DVDNTL <= IBUS_DI & DVDNT_WMASK;

--- a/rtl/SH/SH7604/DMAC.sv
+++ b/rtl/SH/SH7604/DMAC.sv
@@ -227,18 +227,18 @@ module SH7604_DMAC (
 					if (&CHCR[DMA_CH].TS || CHCR[DMA_CH].SM == 2'b01) SAR[DMA_CH] <= SAR[DMA_CH] + AR_INC;
 					else if                (CHCR[DMA_CH].SM == 2'b10) SAR[DMA_CH] <= SAR[DMA_CH] - AR_INC;
 					
-					if (!CHCR[DMA_CH].TA && !LW_CNT) begin
+					if (!CHCR[DMA_CH].TA && (LW_CNT == 2'd0)) begin
 						DMA_RD <= 0;
 						DMA_WR <= 1;
 						DMA_BURST <= &CHCR[DMA_CH].TS;
 						DMA_LOCK <= CHCR[DMA_CH].TB | &CHCR[DMA_CH].TS;
 						LW_CNT <= &CHCR[DMA_CH].TS ? 2'd3 : 2'd0;
 						CH_REQ_CLR[DMA_CH] <= 1;
-						if (!TCR_NEXT) begin
+						if (TCR_NEXT == 24'd0) begin
 							DMA_LOCK <= 0;
 						end
 					end
-					else if (CHCR[DMA_CH].TA && !CHCR[DMA_CH].AM && !LW_CNT) begin
+					else if (CHCR[DMA_CH].TA && !CHCR[DMA_CH].AM && (LW_CNT == 2'd0)) begin
 						CH_REQ_CLR[DMA_CH] <= 1;
 						DMA_REQ_CLR <= 1;
 						LW_CNT <= &CHCR[DMA_CH].TS ? 2'd3 : 2'd0;
@@ -246,7 +246,7 @@ module SH7604_DMAC (
 						if (!CHCR[DMA_CH].TB) DMA_RD <= 0;
 						
 						TCR[DMA_CH] <= TCR_NEXT;
-						if (!TCR_NEXT) begin
+						if (TCR_NEXT == 24'd0) begin
 							CHCR[DMA_CH].TE <= 1;
 							DMA_RD <= 0;
 							DMA_BURST <= 0;
@@ -262,7 +262,7 @@ module SH7604_DMAC (
 					if (LW_CNT == 2'd1) begin
 						if (!CHCR[DMA_CH].TB) DMA_LOCK <= 0;
 					end 
-					if (!LW_CNT || !TCR_NEXT) begin
+					if ((LW_CNT == 2'd0) || (TCR_NEXT == 24'd0)) begin
 						if (!CHCR[DMA_CH].TA) begin
 							DMA_WR <= 0;
 							if (CHCR[DMA_CH].TB) begin
@@ -286,7 +286,7 @@ module SH7604_DMAC (
 					if (TCR_NEXT == 24'd1) begin
 						if (&CHCR[DMA_CH].TS) DMA_LOCK <= 0;
 					end
-					if (!TCR_NEXT) begin
+					if (TCR_NEXT == 24'd0) begin
 						CHCR[DMA_CH].TE <= 1;
 						DMA_RD <= 0;
 						DMA_WR <= 0;
@@ -294,7 +294,7 @@ module SH7604_DMAC (
 					end
 				end
 				
-				if (LW_CNT) LW_CNT <= LW_CNT - 2'd1;
+				if (LW_CNT != 2'd0) LW_CNT <= LW_CNT - 2'd1;
 				else LW_CNT <= &CHCR[DMA_CH].TS ? 2'd3 : 2'd0;
 					
 				RD_BUF[1] <= RD_BUF[0];
@@ -335,6 +335,7 @@ module SH7604_DMAC (
 					case ({IBUS_A[5:2],2'b00})
 						6'h0C: CHCR_TE_OLD[0] <= CHCR[0].TE;
 						6'h1C: CHCR_TE_OLD[1] <= CHCR[1].TE;
+						default:;
 					endcase
 				end
 			end

--- a/rtl/SH/SH7604/FRT.sv
+++ b/rtl/SH/SH7604/FRT.sv
@@ -173,7 +173,7 @@ module SH7604_FRT (
 	bit [ 7: 0] REG_DO;
 	bit         BUSY;
 	always @(posedge CLK or negedge RST_N) begin
-		bit [31: 0] OCR;
+		bit [15: 0] OCR;
 		
 		if (!RST_N) begin
 			TIER <= TIER_INIT;

--- a/rtl/SH/SH7604/INTC.sv
+++ b/rtl/SH/SH7604/INTC.sv
@@ -133,43 +133,43 @@ module SH7604_INTC (
 	assign IRL_REQ = |IRL_LVL; 
 	
 	always_comb begin
-		if      (NMI_REQ                              ) begin INT_ACTIVE <= NMI_INT; end
-		else if (UBC_IRQ     && 4'hF        > INT_MASK) begin INT_ACTIVE <= UBC_INT; end
-		else if (IRL_REQ     && IRL_LVL     > INT_MASK) begin INT_ACTIVE <= IRL_INT; end
-		else if (DIVU_IRQ    && IPRA.DIVUIP > INT_MASK) begin INT_ACTIVE <= DIVU_INT; end
-		else if (DMAC0_IRQ   && IPRA.DMACIP > INT_MASK) begin INT_ACTIVE <= DMAC0_INT; end
-		else if (DMAC1_IRQ   && IPRA.DMACIP > INT_MASK) begin INT_ACTIVE <= DMAC1_INT; end
-		else if (WDT_IRQ     && IPRA.WDTIP  > INT_MASK) begin INT_ACTIVE <= WDT_INT; end
-		else if (BSC_IRQ     && IPRA.WDTIP  > INT_MASK) begin INT_ACTIVE <= BSC_INT; end
-		else if (SCI_ERI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE <= SCI_ERI_INT; end
-		else if (SCI_RXI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE <= SCI_RXI_INT; end
-		else if (SCI_TXI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE <= SCI_TXI_INT; end
-		else if (SCI_TEI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE <= SCI_TEI_INT; end
-		else if (FRT_ICI_IRQ && IPRB.FRTIP  > INT_MASK) begin INT_ACTIVE <= FRT_ICI_INT; end
-		else if (FRT_OCI_IRQ && IPRB.FRTIP  > INT_MASK) begin INT_ACTIVE <= FRT_OCI_INT; end
-		else if (FRT_OVI_IRQ && IPRB.FRTIP  > INT_MASK) begin INT_ACTIVE <= FRT_OVI_INT; end
-		else                                            begin INT_ACTIVE <= '0; end
+		if      (NMI_REQ                              ) begin INT_ACTIVE = NMI_INT; end
+		else if (UBC_IRQ     && 4'hF        > INT_MASK) begin INT_ACTIVE = UBC_INT; end
+		else if (IRL_REQ     && IRL_LVL     > INT_MASK) begin INT_ACTIVE = IRL_INT; end
+		else if (DIVU_IRQ    && IPRA.DIVUIP > INT_MASK) begin INT_ACTIVE = DIVU_INT; end
+		else if (DMAC0_IRQ   && IPRA.DMACIP > INT_MASK) begin INT_ACTIVE = DMAC0_INT; end
+		else if (DMAC1_IRQ   && IPRA.DMACIP > INT_MASK) begin INT_ACTIVE = DMAC1_INT; end
+		else if (WDT_IRQ     && IPRA.WDTIP  > INT_MASK) begin INT_ACTIVE = WDT_INT; end
+		else if (BSC_IRQ     && IPRA.WDTIP  > INT_MASK) begin INT_ACTIVE = BSC_INT; end
+		else if (SCI_ERI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE = SCI_ERI_INT; end
+		else if (SCI_RXI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE = SCI_RXI_INT; end
+		else if (SCI_TXI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE = SCI_TXI_INT; end
+		else if (SCI_TEI_IRQ && IPRB.SCIIP  > INT_MASK) begin INT_ACTIVE = SCI_TEI_INT; end
+		else if (FRT_ICI_IRQ && IPRB.FRTIP  > INT_MASK) begin INT_ACTIVE = FRT_ICI_INT; end
+		else if (FRT_OCI_IRQ && IPRB.FRTIP  > INT_MASK) begin INT_ACTIVE = FRT_OCI_INT; end
+		else if (FRT_OVI_IRQ && IPRB.FRTIP  > INT_MASK) begin INT_ACTIVE = FRT_OVI_INT; end
+		else                                            begin INT_ACTIVE = '0; end
 	end
 	assign INT_REQ = |INT_ACTIVE;
 	
 	always_comb begin
 		case (INT_ACTIVE)
-			NMI_INT:     INT_LVL <= 4'hF;
-			UBC_INT:     INT_LVL <= 4'hF;
-			IRL_INT:     INT_LVL <= IRL_LVL;
-			DIVU_INT:    INT_LVL <= IPRA.DIVUIP;
-			DMAC0_INT:   INT_LVL <= IPRA.DMACIP;
-			DMAC1_INT:   INT_LVL <= IPRA.DMACIP;
-			WDT_INT:     INT_LVL <= IPRA.WDTIP;
-			BSC_INT:     INT_LVL <= IPRA.WDTIP;
-			SCI_ERI_INT: INT_LVL <= IPRB.SCIIP;
-			SCI_RXI_INT: INT_LVL <= IPRB.SCIIP;
-			SCI_TXI_INT: INT_LVL <= IPRB.SCIIP;
-			SCI_TEI_INT: INT_LVL <= IPRB.SCIIP;
-			FRT_ICI_INT: INT_LVL <= IPRB.FRTIP;
-			FRT_OCI_INT: INT_LVL <= IPRB.FRTIP;
-			FRT_OVI_INT: INT_LVL <= IPRB.FRTIP;
-			default:     INT_LVL <= 4'h0;
+			NMI_INT:     INT_LVL = 4'hF;
+			UBC_INT:     INT_LVL = 4'hF;
+			IRL_INT:     INT_LVL = IRL_LVL;
+			DIVU_INT:    INT_LVL = IPRA.DIVUIP;
+			DMAC0_INT:   INT_LVL = IPRA.DMACIP;
+			DMAC1_INT:   INT_LVL = IPRA.DMACIP;
+			WDT_INT:     INT_LVL = IPRA.WDTIP;
+			BSC_INT:     INT_LVL = IPRA.WDTIP;
+			SCI_ERI_INT: INT_LVL = IPRB.SCIIP;
+			SCI_RXI_INT: INT_LVL = IPRB.SCIIP;
+			SCI_TXI_INT: INT_LVL = IPRB.SCIIP;
+			SCI_TEI_INT: INT_LVL = IPRB.SCIIP;
+			FRT_ICI_INT: INT_LVL = IPRB.FRTIP;
+			FRT_OCI_INT: INT_LVL = IPRB.FRTIP;
+			FRT_OVI_INT: INT_LVL = IPRB.FRTIP;
+			default:     INT_LVL = 4'h0;
 		endcase
 	end
 	
@@ -177,22 +177,22 @@ module SH7604_INTC (
 	wire [ 7: 0] IRL_VEC = !ICR.VECMD ? {5'b01000,IRL_LVL_SAVE[3:1]} : VBUS_DI;
 	always_comb begin
 		case (INT_ACCEPTED)
-			NMI_INT:     INT_VEC <= 8'd11;
-			UBC_INT:     INT_VEC <= 8'd12;
-			IRL_INT:     INT_VEC <= IRL_VEC;
-			DIVU_INT:    INT_VEC <= DIVU_VEC;
-			DMAC0_INT:   INT_VEC <= DMAC0_VEC;
-			DMAC1_INT:   INT_VEC <= DMAC1_VEC;
-			WDT_INT:     INT_VEC <= {1'b0,VCRWDT.WITV};
-			BSC_INT:     INT_VEC <= {1'b0,VCRWDT.BCMV};
-			SCI_ERI_INT: INT_VEC <= {1'b0,VCRA.SERV};
-			SCI_RXI_INT: INT_VEC <= {1'b0,VCRA.SRXV};
-			SCI_TXI_INT: INT_VEC <= {1'b0,VCRB.STXV};
-			SCI_TEI_INT: INT_VEC <= {1'b0,VCRB.STEV};
-			FRT_ICI_INT: INT_VEC <= {1'b0,VCRC.FICV};
-			FRT_OCI_INT: INT_VEC <= {1'b0,VCRC.FOCV};
-			FRT_OVI_INT: INT_VEC <= {1'b0,VCRD.FOVV};
-			default:     INT_VEC <= 8'd0;
+			NMI_INT:     INT_VEC = 8'd11;
+			UBC_INT:     INT_VEC = 8'd12;
+			IRL_INT:     INT_VEC = IRL_VEC;
+			DIVU_INT:    INT_VEC = DIVU_VEC;
+			DMAC0_INT:   INT_VEC = DMAC0_VEC;
+			DMAC1_INT:   INT_VEC = DMAC1_VEC;
+			WDT_INT:     INT_VEC = {1'b0,VCRWDT.WITV};
+			BSC_INT:     INT_VEC = {1'b0,VCRWDT.BCMV};
+			SCI_ERI_INT: INT_VEC = {1'b0,VCRA.SERV};
+			SCI_RXI_INT: INT_VEC = {1'b0,VCRA.SRXV};
+			SCI_TXI_INT: INT_VEC = {1'b0,VCRB.STXV};
+			SCI_TEI_INT: INT_VEC = {1'b0,VCRB.STEV};
+			FRT_ICI_INT: INT_VEC = {1'b0,VCRC.FICV};
+			FRT_OCI_INT: INT_VEC = {1'b0,VCRC.FOCV};
+			FRT_OVI_INT: INT_VEC = {1'b0,VCRD.FOVV};
+			default:     INT_VEC = 8'd0;
 		endcase
 	end
 	

--- a/rtl/SH/SH7604/MSBY.sv
+++ b/rtl/SH/SH7604/MSBY.sv
@@ -69,7 +69,7 @@ module SH7604_MSBY (
 		end
 	end
 	
-	assign IBUS_DO = REG_SEL ? REG_DO : 8'h00;
+	assign IBUS_DO = REG_SEL ? REG_DO : 32'h00000000;
 	assign IBUS_BUSY = 0;
 	assign IBUS_ACT = REG_SEL;
 	

--- a/rtl/SH/SH7604/MULT.sv
+++ b/rtl/SH/SH7604/MULT.sv
@@ -62,7 +62,7 @@ module SH7604_MULT (
 			// synopsys translate_on
 		end
 		else begin
-			if (MAC_SEL && MAC_WE && EN && CE_R) begin
+			if ((MAC_SEL != 2'b00) && MAC_WE && EN && CE_R) begin
 				MM_DONE <= 1;
 				case (MAC_OP) 
 					4'b0100,			//LDS Rm,MACx
@@ -116,11 +116,12 @@ module SH7604_MULT (
 						end
 					end
 					4'b1111: {MACH,MACL} <= '0;
+					default:;
 				endcase
 			end
 			
 			if (!MM_DONE && CE_R) begin
-				if (MM_CYC) MM_CYC <= MM_CYC - 2'd1;
+				if (MM_CYC != 2'd0) MM_CYC <= MM_CYC - 2'd1;
 				if (MM_CYC == 2'd1) MM_DONE <= 1;
 			end
 			

--- a/rtl/SH/SH7604/SCI.sv
+++ b/rtl/SH/SH7604/SCI.sv
@@ -408,7 +408,7 @@ module SH7604_SCI
 		end
 	end
 	
-	assign IBUS_DO = REG_SEL ? REG_DO : 8'h00;
+	assign IBUS_DO = REG_SEL ? REG_DO : 32'h00000000;
 	assign IBUS_BUSY = 0;
 	assign IBUS_ACT = REG_SEL;
 	

--- a/rtl/SH/SH7604/UBC.sv
+++ b/rtl/SH/SH7604/UBC.sv
@@ -83,37 +83,37 @@ module SH7604_UBC
 			else if (REG_SEL && IBUS_WE && IBUS_REQ) begin
 				case ({IBUS_A[5:2],2'b00})
 					6'h00: begin
-						if (IBUS_BA[3:2]) BARAH <= IBUS_DI[31:16] & BARx_WMASK;
-						if (IBUS_BA[1:0]) BARAL <= IBUS_DI[15:0]  & BARx_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BARAH <= IBUS_DI[31:16] & BARx_WMASK;
+						if (IBUS_BA[1:0] != 2'b00) BARAL <= IBUS_DI[15:0]  & BARx_WMASK;
 					end
 					6'h04: begin
-						if (IBUS_BA[3:2]) BAMRAH <= IBUS_DI[31:16] & BAMRx_WMASK;
-						if (IBUS_BA[1:0]) BAMRAL <= IBUS_DI[15:0]  & BAMRx_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BAMRAH <= IBUS_DI[31:16] & BAMRx_WMASK;
+						if (IBUS_BA[1:0] != 2'b00) BAMRAL <= IBUS_DI[15:0]  & BAMRx_WMASK;
 					end
 					6'h08: begin
-						if (IBUS_BA[3:2]) BBRA <= IBUS_DI[31:16] & BBRx_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BBRA <= IBUS_DI[31:16] & BBRx_WMASK;
 					end
 					6'h20: begin
-						if (IBUS_BA[3:2]) BARBH <= IBUS_DI[31:16] & BARx_WMASK;
-						if (IBUS_BA[1:0]) BARBL <= IBUS_DI[15:0]  & BARx_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BARBH <= IBUS_DI[31:16] & BARx_WMASK;
+						if (IBUS_BA[1:0] != 2'b00) BARBL <= IBUS_DI[15:0]  & BARx_WMASK;
 					end
 					6'h24: begin
-						if (IBUS_BA[3:2]) BAMRBH <= IBUS_DI[31:16] & BAMRx_WMASK;
-						if (IBUS_BA[1:0]) BAMRBL <= IBUS_DI[15:0]  & BAMRx_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BAMRBH <= IBUS_DI[31:16] & BAMRx_WMASK;
+						if (IBUS_BA[1:0] != 2'b00) BAMRBL <= IBUS_DI[15:0]  & BAMRx_WMASK;
 					end
 					6'h28: begin
-						if (IBUS_BA[3:2]) BBRB <= IBUS_DI[31:16] & BBRx_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BBRB <= IBUS_DI[31:16] & BBRx_WMASK;
 					end
 					6'h30: begin
-						if (IBUS_BA[3:2]) BDRBH <= IBUS_DI[31:16] & BDRB_WMASK;
-						if (IBUS_BA[1:0]) BDRBL <= IBUS_DI[15:0]  & BDRB_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BDRBH <= IBUS_DI[31:16] & BDRB_WMASK;
+						if (IBUS_BA[1:0] != 2'b00) BDRBL <= IBUS_DI[15:0]  & BDRB_WMASK;
 					end
 					6'h34: begin
-						if (IBUS_BA[3:2]) BDMRBH <= IBUS_DI[31:16] & BDMRB_WMASK;
-						if (IBUS_BA[1:0]) BDMRBL <= IBUS_DI[15:0]  & BDMRB_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BDMRBH <= IBUS_DI[31:16] & BDMRB_WMASK;
+						if (IBUS_BA[1:0] != 2'b00) BDMRBL <= IBUS_DI[15:0]  & BDMRB_WMASK;
 					end
 					6'h38: begin
-						if (IBUS_BA[3:2]) BRCR <= IBUS_DI[31:16] & BRCR_WMASK;
+						if (IBUS_BA[3:2] != 2'b00) BRCR <= IBUS_DI[31:16] & BRCR_WMASK;
 					end
 					default:;
 				endcase

--- a/rtl/SH/core/SH_core.sv
+++ b/rtl/SH/core/SH_core.sv
@@ -98,7 +98,7 @@ module SH_core
 	
 `ifdef DEBUG
 	assign REGS_RAN = EN ? ID_DECI.RA.N : DBG_REGN;
-`elsif
+`else
 	assign REGS_RAN = ID_DECI.RA.N;
 `endif
 	assign REGS_RBN = ID_DECI.RB.N;
@@ -238,7 +238,7 @@ module SH_core
 					SAVE_IR <= BUS_DI[15:0];
 				end
 				
-				if (!ID_DECI.LST) begin
+				if (ID_DECI.LST == 3'd0) begin
 					PIPE.ID.IR <= NEW_IR;
 					PIPE.ID.PC <= PC;
 				end
@@ -257,7 +257,7 @@ module SH_core
 					INT_REQ_LATCH <= 0;
 				end
 			
-				if (ID_DECI.LST && STATE == ID_DECI.LST) begin
+				if ((ID_DECI.LST != 3'd0) && (STATE == ID_DECI.LST)) begin
 					PIPE.ID <= SAVE_ID;
 				end
 			end
@@ -269,7 +269,6 @@ module SH_core
 	//**********************************************************
 	assign ID_STALL = BUS_STALL | INST_SPLIT;
 	
-	assign BR_COND = ID_DECI.BR.BI & ((SR_T == ID_DECI.BR.BCV) | (ID_DECI.BR.BT == UCB));
 	wire ID_DELAY_SLOT = ~PIPE.EX.DI.BR.BI & (PIPE.EX.DI.BR.BT == CB | PIPE.EX.DI.BR.BT == UCB);
 	
 	wire [15:0] DEC_IR = (INT_REQ | INT_REQ_LATCH) && !ID_DELAY_SLOT && !IFID_STALL ? 16'hF100 : 
@@ -277,10 +276,15 @@ module SH_core
 								ID_DELAY_SLOT && !PIPE.EX.DI.BR.BD ? 16'h0009 :
 								IFID_STALL ? PIPE.EX.IR : PIPE.ID.IR;
 								
-	assign ID_DECI = Decode(DEC_IR, STATE, BR_COND, VER);
+	DecInstr_t ID_DECI_RAW;
+	wire BR_COND_DEC;
+	assign ID_DECI_RAW = Decode(DEC_IR, STATE, 1'b0, VER);
+	assign BR_COND_DEC = ID_DECI_RAW.BR.BI & ((SR_T == ID_DECI_RAW.BR.BCV) | (ID_DECI_RAW.BR.BT == UCB));
+	assign BR_COND = BR_COND_DEC;
+	assign ID_DECI = Decode(DEC_IR, STATE, BR_COND_DEC, VER);
 	
 	
-	wire BP_T_EXID = ID_DECI.BR.BI & ID_DECI.BR.BT == CB & PIPE.EX.DI.CTRL.W & PIPE.EX.DI.CTRL.S == SR_;
+	wire BP_T_EXID = ID_DECI_RAW.BR.BI & ID_DECI_RAW.BR.BT == CB & PIPE.EX.DI.CTRL.W & PIPE.EX.DI.CTRL.S == SR_;
 	always_comb begin
 		if (BP_T_EXID) begin
 			SR_T = SR_NEW.T;
@@ -389,6 +393,7 @@ module SH_core
 			ZERO:   temp = 32'h00000000;
 			ONE:    temp = 32'h00000001;
 			VECT:   temp = {{24{1'b0}},      vec};
+			default: temp = 32'h00000000;
 		endcase
 		
 		if (PIPE.EX.DI.BR.BI) begin
@@ -405,6 +410,7 @@ module SH_core
 			SR_:  SCR_VAL = SR & 32'h000003F3;
 			GBR_: SCR_VAL = GBR;
 			VBR_: SCR_VAL = VBR;
+			default: SCR_VAL = 32'h00000000;
 		endcase
 		
 		if (BP_A_EXEX) begin
@@ -520,7 +526,7 @@ module SH_core
 		endcase
 		
 		adder_a = PIPE.EX.DI.ALU.OP == DIV ? {ALU_A[30:0],SR.T} : ALU_A;
-		adder_code = PIPE.EX.DI.ALU.OP == DIV ? {1'b0,SR.M~^SR.Q} : PIPE.EX.DI.ALU.CD;
+		adder_code = PIPE.EX.DI.ALU.OP == DIV ? {3'b000,(SR.M ~^ SR.Q)} : PIPE.EX.DI.ALU.CD;
 		adder_cmp = PIPE.EX.DI.ALU.CMP;
 		{ADDER_C,ADDER_RES} = Adder(adder_a,ALU_B,SR.T,adder_code);
 		ADDER_V = ~((ALU_A[31] ^ ALU_B[31]) ^ adder_code[0]) & (ALU_A[31] ^ ADDER_RES[31]);
@@ -554,32 +560,36 @@ module SH_core
 						2'b11: ALU_T = ge_hs & ~eq;
 						default:;
 					endcase
-					2'b10: ALU_T <= ADDER_C;
-					2'b11: ALU_T <= ADDER_V;
+					2'b10: ALU_T = ADDER_C;
+					2'b11: ALU_T = ADDER_V;
 					default:;
 				endcase
-			LOG: ALU_T <= PIPE.EX.DI.ALU.CD[3] ? str_eq : LOG_Z;
-			SHIFT: ALU_T <= SHIFT_C;
-			DIV: ALU_T <= ADDER_C;
+			LOG: ALU_T = PIPE.EX.DI.ALU.CD[3] ? str_eq : LOG_Z;
+			SHIFT: ALU_T = SHIFT_C;
+			DIV: ALU_T = ADDER_C;
 			default:;
 		endcase
 	end
 	
 	bit [31: 0] MA_ADDR;
 	always_comb begin
+		MA_ADDR = ALU_RES;
 		case (PIPE.EX.DI.MEM.ADDS)
 			ALUA:    MA_ADDR = REG_A;
 			ALUB:    MA_ADDR = REG_B;
 			ALURES:  MA_ADDR = ALU_RES;
+			default:;
 		endcase
 	end
 	
 	bit [31: 0] MA_WD;
 	always_comb begin
+		MA_WD = ALU_RES;
 		case (PIPE.EX.DI.MEM.WDS)
 			ALUA: MA_WD = REG_A;
 			ALUB: MA_WD = REG_B;
 			ALURES: MA_WD = ALU_RES;
+			default:;
 		endcase
 	end
 	
@@ -641,6 +651,7 @@ module SH_core
 				SR_NEW.T = 0;
 			end
 			IMSK: SR_NEW.I = INT_LVL_LATCH;
+			default:;
 		endcase
 	end
 	

--- a/rtl/SH/core/SH_pkg.sv
+++ b/rtl/SH/core/SH_pkg.sv
@@ -1,3 +1,6 @@
+`ifndef SH2_PKG_SV
+`define SH2_PKG_SV
+
 package SH2_PKG;
 
 	typedef enum bit[2:0] {
@@ -1440,3 +1443,5 @@ package SH2_PKG;
 	endfunction
 	
 endpackage
+
+`endif

--- a/rtl/SH/core/SH_regfile.sv
+++ b/rtl/SH/core/SH_regfile.sv
@@ -74,7 +74,7 @@ module SH2_regfile (
 			if (WAE && CE) begin
 				GR[WA_ADDR] <= WA_D;
 			end
-			if (WBE_SAVE) begin
+			if (WBE_LATCH) begin
 				GR[WB_ADDR_LATCH] <= WB_D_LATCH;
 			end
 		end
@@ -89,10 +89,10 @@ module SH2_regfile (
 			GR0 <= '0;
 		end
 		else if (EN) begin
-			if (WAE && !WA_ADDR && CE) begin
+			if (WAE && (WA_ADDR == 5'd0) && CE) begin
 				GR0 <= WA_D;
 			end
-			if (WBE_LATCH && !WB_ADDR_LATCH) begin
+			if (WBE_LATCH && (WB_ADDR_LATCH == 5'd0)) begin
 				GR0 <= WB_D_LATCH;
 			end
 		end
@@ -151,10 +151,10 @@ module SH2_regfile (
 			GR0 <= '0;
 		end
 		else if (EN) begin
-			if (WAE && !WA_ADDR && CE) begin
+			if (WAE && (WA_ADDR == 5'd0) && CE) begin
 				GR0 <= WA_D;
 			end
-			if (WBE_LATCH && !WB_ADDR_LATCH) begin
+			if (WBE_LATCH && (WB_ADDR_LATCH == 5'd0)) begin
 				GR0 <= WB_D_LATCH;
 			end
 		end


### PR DESCRIPTION
This cleans all the verilator warnings and makes the code clean for simulation. The edits fall in these categories:

- incorrect return bit width of SDRAMBank
- explicit == and != comparisons instead of using ! for multi-bit variables. This makes things a bit verbose, but clearer
- incorrect bit width for operands in some expressions
- correct use of blocking assignments in combinational logic
- added `default` to case statements (was there an incorrect latch inference for temp/SCR_VAL before?)

There are a couple of lines that look a bit worrying in the original code without these changes. But most of the changes just make the code tool friendly keeping the same logic.