### PR TITLE
SMPC: fix MD_ID precedence in stunner/nothing detection

### DIFF
--- a/rtl/Saturn/SMPC.sv
+++ b/rtl/Saturn/SMPC.sv
@@ -1033,7 +1033,7 @@ module SMPC (
 							PORT_ST <= PS_MOUSE_0;
 						else if (MD_ID == 4'h5)
 							PORT_ST <= PS_ID5_0;
-						else if (MD_ID == 4'hF || 4'hA)
+						else if (MD_ID == 4'hF || MD_ID == 4'hA)
 							PORT_ST <= PS_NOTHING_STUNNER;
 						else 
 							PORT_ST <= PS_END;


### PR DESCRIPTION
## Summary

The `else if (MD_ID == 4'hF || 4'hA)` line introduced in #252 doesn't do
what it looks like. Because `==` binds tighter than `||` in
SystemVerilog, the expression parses as

```verilog
(MD_ID == 4'hF) || (4'hA)
```

The right-hand operand of `||` is the bare literal `4'hA`, which is a
non-zero constant and therefore reduces to logical `1` in any boolean
context. The whole condition is unconditionally true, so every `MD_ID`
that didn't match the earlier branches (`4'hB`, `4'h3`, `4'h5`) lands in
`PS_NOTHING_STUNNER` and the explicit `else PORT_ST <= PS_END` fallback
becomes dead code.

Empirical confirmation with iverilog (`-g2012`):

```
MD_ID  | (MD_ID == 4'hF || 4'hA) | (MD_ID == 4'hF || MD_ID == 4'hA)
-------+--------------------------+----------------------------------
  0    |            1             |                0
  1    |            1             |                0
  ...  |           ...            |               ...
  a    |            1             |                1
  b    |            1             |                0
  ...
  f    |            1             |                1
```

The buggy form returns `1` for all 16 values; the corrected form is `1`
only for `4'hA` and `4'hF`, which matches the surrounding code's
intent (`//Nothing Detected or Stunner`).

This is currently benign because `PS_NOTHING_STUNNER` emits
`{MD_ID, 4'b0000}` verbatim and the host treats unknown IDs as "no
pad", but the explicit `PS_END` branch is unreachable today and any
future logic that relies on `PS_END` would silently misbehave.

## Test plan

- [ ] Re-test SNAC Stunner detection on real hardware (no behavior
      change expected for `MD_ID = 4'hA` / `4'hF`).
- [ ] Confirm that an unrecognised `MD_ID` (e.g. an unsupported
      peripheral) now reaches `PS_END` instead of being misclassified
      as Stunner.