### PR TITLE
Update Saturn README status wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Status
 
-Current status is WIP/Beta
+The core has matured substantially, with many games tested over the course of development.
 
-Known issues:
+Known issues and limitations are tracked in this repository's issue list rather than in a game-by-game list here.
 


### PR DESCRIPTION
Fixes #507.

This updates the README status wording so the Saturn core no longer appears inactive or unknown-status from the documentation alone.

The update keeps the wording conservative:

- no compatibility/game list is added
- no claim of perfect or complete compatibility is made
- no claim that all games work is made
- known bugs and limitations remain directed to the GitHub issue tracker

Changed file:

- "README.md"

No HDL, build files, project files, gameplay logic, ROM definitions, or timing behavior are changed.

Validation performed:

- confirmed README wording follows the issue discussion
- confirmed no game compatibility list was added
- confirmed no overbroad compatibility claim was introduced
- "git diff --check"
- "git diff --cached --check"
- "git show --check HEAD"

Markdown linting was not run because "markdownlint" is not installed and this repo has no Markdown lint setup.

No MiSTer hardware validation is required because this is documentation-only.