### PR TITLE
[codex] Add ST-V Shienryu 180 flip final build

### DIFF
--- a/STV_DS.qsf
+++ b/STV_DS.qsf
@@ -13,7 +13,7 @@ set_global_assignment -name PARTITION_NETLIST_TYPE SOURCE -section_id Top
 set_global_assignment -name PARTITION_FITTER_PRESERVATION_LEVEL PLACEMENT_AND_ROUTING -section_id Top
 set_global_assignment -name PARTITION_COLOR 16764057 -section_id Top
 
-set_global_assignment -name LAST_QUARTUS_VERSION "17.0.2 Standard Edition"
+set_global_assignment -name LAST_QUARTUS_VERSION "25.1std.0 Standard Edition"
 
 set_global_assignment -name GENERATE_RBF_FILE ON
 set_global_assignment -name PROJECT_OUTPUT_DIRECTORY output_files
@@ -44,10 +44,12 @@ set_global_assignment -name ADV_NETLIST_OPT_SYNTH_WYSIWYG_REMAP ON
 set_global_assignment -name SYNTH_GATED_CLOCK_CONVERSION ON
 set_global_assignment -name PRE_MAPPING_RESYNTHESIS ON
 set_global_assignment -name ROUTER_CLOCKING_TOPOLOGY_ANALYSIS ON
+set_global_assignment -name ROUTER_TIMING_OPTIMIZATION_LEVEL MAXIMUM
 set_global_assignment -name ECO_OPTIMIZE_TIMING ON
 set_global_assignment -name PERIPHERY_TO_CORE_PLACEMENT_AND_ROUTING_OPTIMIZATION ON
 set_global_assignment -name PHYSICAL_SYNTHESIS_ASYNCHRONOUS_SIGNAL_PIPELINING ON
 set_global_assignment -name ALM_REGISTER_PACKING_EFFORT LOW
+set_global_assignment -name OPTIMIZE_HOLD_TIMING "ALL PATHS"
 set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 2.0
 set_global_assignment -name SEED 1
 

--- a/Saturn.sv
+++ b/Saturn.sv
@@ -37,6 +37,7 @@ module emu
 	//if VIDEO_ARX[12] or VIDEO_ARY[12] is set then [11:0] contains scaled size instead of aspect ratio.
 	output [12:0] VIDEO_ARX,
 	output [12:0] VIDEO_ARY,
+	output        VIDEO_FLIP_180,
 
 	output  [7:0] VGA_R,
 	output  [7:0] VGA_G,
@@ -192,7 +193,12 @@ module emu
 	assign VGA_SCALER= 0;
 	assign HDMI_BLACKOUT = 1;
 	assign HDMI_BOB_DEINT = status[29];
-	
+`ifdef STV_BUILD
+	assign VIDEO_FLIP_180 = status[82];
+`else
+	assign VIDEO_FLIP_180 = 0;
+`endif
+
 	wire [1:0] ar = status[63:62];
 	wire [7:0] arx,ary;
 
@@ -322,6 +328,7 @@ module emu
 		"D8P1o[54:51],Crop Offset,0,2,4,8,10,12,-12,-10,-8,-6,-4,-2;",
 		"P1o[56:55],Scale,Normal,V-Integer,Narrower HV-Integer,Wider HV-Integer;",
 `ifdef STV_BUILD
+		"P1o[82],Shienryu 180 Flip,Off,On;",
 		"P1-;",
 		"P1o[75],CRT H/V offset,Off,On;",
 		"D5P1o[69:65],CRT H offset,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2,-1;",

--- a/releases/stv_flip_v1.1_final.rbf.sha256
+++ b/releases/stv_flip_v1.1_final.rbf.sha256
@@ -1,0 +1,1 @@
+bf1a726b0e7ac5e41a8262ea1db54bcc613c56355dcb0e4bcce5826820044b31  stv_flip_v1.1_final.rbf

--- a/releases/stv_flip_v1.1_final_README.md
+++ b/releases/stv_flip_v1.1_final_README.md
@@ -1,0 +1,63 @@
+# ST-V Shienryu 180 Flip v1.1 Final
+
+Experimental dual-SDRAM ST-V build for testing Shienryu with a 180-degree active-video flip.
+
+## Files
+
+- `stv_flip_v1.1_final.rbf`
+- `stv_flip_v1.1_final.rbf.sha256`
+
+This is the physically tested `stv_flip_v1.1_rc1` build promoted to final. The RBF content is unchanged.
+
+## Purpose
+
+Adds an ST-V OSD option:
+
+`Shienryu 180 Flip = Off/On`
+
+Default is `Off`. With the option off, normal ST-V behavior is preserved. With the option on, the late scaler/ascal video path flips the active game image horizontally and vertically for a 180-degree correction. The MiSTer OSD itself is not separately rotated.
+
+## Video Scope
+
+The flip is applied in the HDMI/scaler output path through `ascal.vhd`. Direct analog/raw video paths are not expected to be transformed by this experimental option.
+
+## Timing Summary
+
+Quartus: 25.1 Standard
+
+- Setup slack: -0.089 ns
+- Hold slack: -0.330 ns
+- Full compile: 00:57:02
+- Fitter: 00:50:10
+- Fitter peak memory: 11,194 MB
+
+Resource summary:
+
+- ALMs: 39,994 / 41,910 (95%)
+- Registers: 41,915
+- Block memory bits: 4,126,357 / 5,662,720 (73%)
+- RAM blocks: 553 / 553 (100%)
+- DSP blocks: 63 / 112 (56%)
+- PLLs: 3 / 6 (50%)
+
+## SHA256
+
+`bf1a726b0e7ac5e41a8262ea1db54bcc613c56355dcb0e4bcce5826820044b31`
+
+## Validation
+
+- Built from the ST-V dual-SDRAM project.
+- Shienryu boots.
+- `Shienryu 180 Flip` was physically verified on HDMI output.
+- Flip off/on behavior was checked with MiSTerClaw captures and physical monitor photos.
+- Audio, controls, coin/start, and gameplay were confirmed during manual testing.
+
+## Hardware Test Checklist
+
+1. Install `stv_flip_v1.1_final.rbf` as an ST-V arcade core.
+2. Launch Shienryu.
+3. Open OSD and set `Shienryu 180 Flip` to `On`.
+4. Confirm the game image is corrected by a 180-degree flip.
+5. Confirm the OSD behavior separately; OSD rotation is not required.
+6. Confirm controls, coin/start, audio, and gameplay still work.
+7. Test one non-Shienryu ST-V game with `Shienryu 180 Flip = Off`.

--- a/sys/ascal.vhd
+++ b/sys/ascal.vhd
@@ -204,7 +204,8 @@ ENTITY ascal IS
 		run       : IN std_logic :='1'; -- 1=Enable output image. 0=No image
 		freeze    : IN std_logic :='0'; -- 1=Disable framebuffer writes
 		mode      : IN unsigned(4 DOWNTO 0);
- 		bob_deint : IN std_logic := '0';
+		flip_180  : IN std_logic := '0';
+		bob_deint : IN std_logic := '0';
 		-- SYNC  |_________________________/"""""""""\_______|
 		-- DE    |""""""""""""""""""\________________________|
 		-- RGB   |    <#IMAGE#>      ^HDISP                  |
@@ -447,6 +448,7 @@ ARCHITECTURE rtl OF ascal IS
 	SIGNAL o_run : std_logic;
 	SIGNAL o_freeze : std_logic;
 	SIGNAL o_bob_deint : std_logic;
+	SIGNAL o_flip_180 : std_logic;
 	SIGNAL o_iwfl : std_logic_vector(2 DOWNTO 0);
 	SIGNAL o_mode,o_hmode,o_vmode : unsigned(4 DOWNTO 0);
 	SIGNAL o_format : unsigned(5 DOWNTO 0);
@@ -484,6 +486,9 @@ ARCHITECTURE rtl OF ascal IS
 	SIGNAL o_copyv : unsigned(0 TO 14);
 	SIGNAL o_adrs : unsigned(31 DOWNTO 0); -- Avalon address
 	SIGNAL o_adrs_pre : natural RANGE 0 TO 2**24-1;
+	SIGNAL o_flip_adrs_pre : natural RANGE 0 TO 2**24-1;
+	SIGNAL o_flip_fload2_adrs : natural RANGE 0 TO 2**24-1;
+	SIGNAL o_flip_fload1_adrs : natural RANGE 0 TO 2**24-1;
 	SIGNAL o_stride : unsigned(13 DOWNTO 0);
 	SIGNAL o_adrsa,o_adrsb,o_rline : std_logic;
 	SIGNAL o_ad,o_ad1,o_ad2,o_ad3 : natural RANGE 0 TO 2*BLEN-1;
@@ -1874,6 +1879,10 @@ BEGIN
 			o_copy<=sWAIT;
 			o_state<=sDISP;
 			o_read_pre<='0';
+			o_flip_180<='0';
+			o_flip_adrs_pre<=0;
+			o_flip_fload2_adrs<=0;
+			o_flip_fload1_adrs<=0;
 			o_readlev<=0;
 			o_copylev<=0;
 			o_hsp<='0';
@@ -1884,6 +1893,7 @@ BEGIN
 			o_format <="0001" & format; -- <ASYNC> ?
 
 			o_run    <=run; -- <ASYNC> ?
+			o_flip_180 <= flip_180; -- <ASYNC> ?
 
 			o_htotal <=htotal; -- <ASYNC> ?
 			o_hsstart<=hsstart; -- <ASYNC> ?
@@ -2003,6 +2013,17 @@ BEGIN
 			ELSE
 				o_stride<=to_unsigned(o_ihsize_temp2,14);
 				o_stride(NB_BURST-1 DOWNTO 0)<=(OTHERS =>'0');
+			END IF;
+
+			IF o_ivsize>0 THEN
+				o_flip_fload2_adrs <= (o_ivsize - 1) * to_integer(o_stride);
+			ELSE
+				o_flip_fload2_adrs <= 0;
+			END IF;
+			IF o_ivsize>1 THEN
+				o_flip_fload1_adrs <= (o_ivsize - 2) * to_integer(o_stride);
+			ELSE
+				o_flip_fload1_adrs <= 0;
 			END IF;
 			------------------------------------------------------
 			o_hmode<=o_mode;
@@ -2166,15 +2187,33 @@ BEGIN
 				o_adrs_pre<=to_integer(o_vacpt) * to_integer(o_stride);
 			END IF;
 
+			IF o_adrs_pre<=o_flip_fload2_adrs THEN
+				o_flip_adrs_pre<=o_flip_fload2_adrs - o_adrs_pre;
+			ELSE
+				o_flip_adrs_pre<=0;
+			END IF;
+
 			IF o_adrsa='1' THEN
 				IF o_fload=2 THEN
-					o_adrs<=to_unsigned(o_hbcpt * N_BURST,32);
+					IF o_flip_180='1' THEN
+						o_adrs<=to_unsigned(o_flip_fload2_adrs + (o_hbcpt * N_BURST),32);
+					ELSE
+						o_adrs<=to_unsigned(o_hbcpt * N_BURST,32);
+					END IF;
 					o_alt<="1111";
 				ELSIF o_fload=1 THEN
-					o_adrs<=to_unsigned(o_hbcpt * N_BURST,32) + o_stride;
+					IF o_flip_180='1' THEN
+						o_adrs<=to_unsigned(o_flip_fload1_adrs + (o_hbcpt * N_BURST),32);
+					ELSE
+						o_adrs<=to_unsigned(o_hbcpt * N_BURST,32) + o_stride;
+					END IF;
 					o_alt<="0100";
 				ELSE
-					o_adrs<=to_unsigned(o_adrs_pre + (o_hbcpt * N_BURST),32);
+					IF o_flip_180='1' THEN
+						o_adrs<=to_unsigned(o_flip_adrs_pre + (o_hbcpt * N_BURST),32);
+					ELSE
+						o_adrs<=to_unsigned(o_adrs_pre + (o_hbcpt * N_BURST),32);
+					END IF;
 					o_alt<=altx(o_vacptl + 1);
 				END IF;
 			END IF;
@@ -2684,7 +2723,11 @@ BEGIN
 			o_h_poly_pix<=poly_final(o_h_poly_t);
 
 			-- C11 : Select interpoler ----------------------------
-			o_wadl<=o_dcptv(14);
+			IF o_flip_180='1' AND o_dcptv(14)<o_hsize THEN
+				o_wadl<=o_hsize - 1 - o_dcptv(14);
+			ELSE
+				o_wadl<=o_dcptv(14);
+			END IF;
 			o_wr<=o_altx AND (o_copyv(14) & o_copyv(14) & o_copyv(14) & o_copyv(14));
 			o_ldw<=(x"00",x"00",x"00");
 

--- a/sys/sys_top.sdc
+++ b/sys/sys_top.sdc
@@ -72,6 +72,7 @@ set_false_path -from {ascal|o_hdisp* ascal|o_vdisp*}
 set_false_path -from {ascal|o_htotal* ascal|o_vtotal*}
 set_false_path -from {ascal|o_hsstart* ascal|o_vsstart* ascal|o_hsend* ascal|o_vsend*}
 set_false_path -from {ascal|o_hsize* ascal|o_vsize*}
+set_false_path -from {ascal|o_flip_180}
 
 set_false_path -from {mcp23009|flg_*}
 set_false_path -to   {sysmem|fpga_interfaces|clocks_resets|f2h*}

--- a/sys/sys_top.v
+++ b/sys/sys_top.v
@@ -322,6 +322,7 @@ reg  [9:0] coef_data;
 reg        coef_wr = 0;
 
 wire[12:0] ARX, ARY;
+wire       video_flip_180;
 reg [11:0] VSET = 0, HSET = 0;
 reg        FREESCALE = 0;
 reg  [2:0] scaler_flt;
@@ -764,6 +765,7 @@ wire         bob_deint;
 		.swblack  (hdmi_blackout),
 
 		.mode     ({~lowlat,LFB_EN ? LFB_FLT : |scaler_flt,2'b00}),
+		.flip_180 (video_flip_180),
 		.poly_clk (clk_sys),
 		.poly_a   (coef_addr),
 		.poly_dw  (coef_data),
@@ -1764,6 +1766,7 @@ emu emu
 	.VGA_SL(scanlines),
 	.VIDEO_ARX(ARX),
 	.VIDEO_ARY(ARY),
+	.VIDEO_FLIP_180(video_flip_180),
 
 `ifdef MISTER_FB
 	.FB_EN(fb_en),


### PR DESCRIPTION
## What changed

- Adds an ST-V-only `Shienryu 180 Flip` OSD option at status bit 82.
- Routes the option through `sys_top.v` into `ascal.vhd`.
- Applies the 180-degree flip late in the HDMI/scaler path by flipping framebuffer read/write addressing in `ascal`.
- Includes the promoted final experimental RBF as `releases/stv_flip_v1.1_final.rbf` plus SHA256 and README.

## Build status

This is the physically tested `stv_flip_v1.1_rc1` build promoted to final. The RBF content is unchanged.

Timing summary from Quartus 25.1 Standard:

- Setup slack: `-0.089 ns`
- Hold slack: `-0.330 ns`
- Full compile: `00:57:02`
- Fitter: `00:50:10`
- SHA256: `bf1a726b0e7ac5e41a8262ea1db54bcc613c56355dcb0e4bcce5826820044b31`

## Validation

- Built from the ST-V dual-SDRAM project.
- Shienryu boots.
- Dale physically confirmed the 180-degree flip works on HDMI output.
- MiSTerClaw captures were used for off/on sanity checks, with the final flip confirmed by physical monitor photos.
- Controls, coin/start, audio, and gameplay were checked during manual testing.

## Notes

This is intentionally experimental and does not change default ST-V behavior because the new option defaults to `Off`.
